### PR TITLE
Implement `CircuitExt` for `EvmCircuit`

### DIFF
--- a/snark-verifier-sdk/Cargo.toml
+++ b/snark-verifier-sdk/Cargo.toml
@@ -28,13 +28,14 @@ ethereum-types = { version = "0.14", default-features = false, features = ["std"
 # rlp = { version = "0.5", default-features = false, features = ["std"], optional = true }
 
 # zkevm benchmarks
-zkevm-circuits = { git = "https://github.com/scroll-tech/zkevm-circuits.git", branch = "halo2-ecc-snark-verifier-0323", features = ["test"] }
+zkevm-circuits = { git = "https://github.com/scroll-tech/zkevm-circuits.git", branch = "halo2-ecc-snark-verifier-0323", features = ["test", "zktrie"] }
 bus-mapping = { git = "https://github.com/scroll-tech/zkevm-circuits.git", branch = "halo2-ecc-snark-verifier-0323", optional = true }
 eth-types = { git = "https://github.com/scroll-tech/zkevm-circuits.git", branch = "halo2-ecc-snark-verifier-0323" }
 mock = { git = "https://github.com/scroll-tech/zkevm-circuits.git", branch = "halo2-ecc-snark-verifier-0323", optional = true }
 
 [dev-dependencies]
 ark-std = { version = "0.3.0", features = ["print-trace"] }
+ethers-signers = { version = "0.17.0" }
 paste = "1.0.7"
 pprof = { version = "0.11", features = ["criterion", "flamegraph"] }
 criterion = "0.4"

--- a/snark-verifier-sdk/src/evm_circuits/evm_circuit.rs
+++ b/snark-verifier-sdk/src/evm_circuits/evm_circuit.rs
@@ -11,6 +11,6 @@ impl<F: Field> CircuitExt<F> for EvmCircuit<F> {
     }
 
     fn instances(&self) -> Vec<Vec<F>> {
-        vec![vec![]]
+        vec![]
     }
 }

--- a/snark-verifier-sdk/src/evm_circuits/evm_circuit.rs
+++ b/snark-verifier-sdk/src/evm_circuits/evm_circuit.rs
@@ -1,5 +1,4 @@
 use eth_types::Field;
-use halo2_base::halo2_proofs::plonk::Selector;
 use zkevm_circuits::evm_circuit::EvmCircuit;
 
 use crate::CircuitExt;
@@ -8,19 +7,10 @@ impl<F: Field> CircuitExt<F> for EvmCircuit<F> {
     /// Return the number of instances of the circuit.
     /// This may depend on extra circuit parameters but NOT on private witnesses.
     fn num_instance(&self) -> Vec<usize> {
-        todo!()
+        vec![0]
     }
 
     fn instances(&self) -> Vec<Vec<F>> {
-        todo!()
-    }
-
-    fn accumulator_indices() -> Option<Vec<(usize, usize)>> {
-        todo!()
-    }
-
-    /// Output the simple selector columns (before selector compression) of the circuit
-    fn selectors(_: &Self::Config) -> Vec<Selector> {
-        todo!()
+        vec![vec![]]
     }
 }

--- a/snark-verifier-sdk/src/evm_circuits/mod.rs
+++ b/snark-verifier-sdk/src/evm_circuits/mod.rs
@@ -38,28 +38,24 @@ mod test {
         assert!(verify_circuit(circuit));
     }
 
-    #[ignore]
     #[test]
     fn test_mpt_circuit_verification() {
         let circuit = super_circuit().mpt_circuit;
         assert!(verify_circuit(circuit));
     }
 
-    #[ignore]
     #[test]
     fn test_poseidon_circuit_verification() {
         let circuit = super_circuit().poseidon_circuit;
         assert!(verify_circuit(circuit));
     }
 
-    #[ignore]
     #[test]
     fn test_state_circuit_verification() {
         let circuit = super_circuit().state_circuit;
         assert!(verify_circuit(circuit));
     }
 
-    #[ignore]
     #[test]
     fn test_super_circuit_verification() {
         let circuit = super_circuit();

--- a/snark-verifier-sdk/src/evm_circuits/mod.rs
+++ b/snark-verifier-sdk/src/evm_circuits/mod.rs
@@ -8,23 +8,143 @@ mod poseidon_circuit;
 mod state_circuit;
 mod super_circuit;
 
-#[cfg(test)]
+#[cfg(all(test, feature = "zkevm"))]
 mod test {
-    use ark_std::test_rng;
-    use halo2_base::{halo2_proofs::halo2curves::bn256::Fr, utils::fs::gen_srs};
-
     use crate::{
         gen_pk,
         halo2::{gen_snark_shplonk, verify_snark_shplonk},
         CircuitExt,
     };
+    use ark_std::test_rng;
+    use bus_mapping::circuit_input_builder::CircuitsParams;
+    use eth_types::{address, bytecode, geth_types::GethData, U256};
+    use ethers_signers::{LocalWallet, Signer};
+    use halo2_base::{halo2_proofs::halo2curves::bn256::Fr, utils::fs::gen_srs};
+    use mock::{TestContext, MOCK_CHAIN_ID, MOCK_DIFFICULTY};
+    use rand::SeedableRng;
+    use rand_chacha::ChaCha20Rng;
+    use std::{collections::HashMap, env};
+    use zkevm_circuits::super_circuit::SuperCircuit;
 
-    // A simple unit test to check that C has implemented CircuitExt correctly.
-    pub(crate) fn test_circuit_native_verification<C: CircuitExt<Fr>>(circuit: C) -> bool {
-        std::env::set_var("VERIFY_CONFIG", "./configs/verify_circuit.config");
+    const TEST_CURRENT_K: u32 = 18;
+    const TEST_MAX_CALLDATA: usize = 32;
+    const TEST_MAX_INNER_BLOCKS: usize = 1;
+    const TEST_MAX_TXS: usize = 1;
+    const TEST_MOCK_RANDOMNESS: u64 = 0x100;
+
+    #[test]
+    fn test_evm_circuit_verification() {
+        let circuit = super_circuit().evm_circuit;
+        assert!(verify_circuit(circuit));
+    }
+
+    #[ignore]
+    #[test]
+    fn test_mpt_circuit_verification() {
+        let circuit = super_circuit().mpt_circuit;
+        assert!(verify_circuit(circuit));
+    }
+
+    #[ignore]
+    #[test]
+    fn test_poseidon_circuit_verification() {
+        let circuit = super_circuit().poseidon_circuit;
+        assert!(verify_circuit(circuit));
+    }
+
+    #[ignore]
+    #[test]
+    fn test_state_circuit_verification() {
+        let circuit = super_circuit().state_circuit;
+        assert!(verify_circuit(circuit));
+    }
+
+    #[ignore]
+    #[test]
+    fn test_super_circuit_verification() {
+        let circuit = super_circuit();
+        assert!(verify_circuit(circuit));
+    }
+
+    fn super_circuit() -> SuperCircuit<
+        Fr,
+        TEST_MAX_TXS,
+        TEST_MAX_CALLDATA,
+        TEST_MAX_INNER_BLOCKS,
+        TEST_MOCK_RANDOMNESS,
+    > {
+        let block = block_1tx();
+        let circuits_params = CircuitsParams {
+            max_txs: TEST_MAX_TXS,
+            max_calldata: TEST_MAX_CALLDATA,
+            max_rws: 256,
+            max_copy_rows: 256,
+            max_exp_steps: 256,
+            max_bytecode: 512,
+            // TODO: fix after zkevm-circuits update.
+            // max_evm_rows: 0,
+            // max_keccak_rows: 0,
+            keccak_padding: None,
+            max_inner_blocks: TEST_MAX_INNER_BLOCKS,
+        };
+        let mut difficulty_be_bytes = [0u8; 32];
+        let mut chain_id_be_bytes = [0u8; 32];
+        MOCK_DIFFICULTY.to_big_endian(&mut difficulty_be_bytes);
+        MOCK_CHAIN_ID.to_big_endian(&mut chain_id_be_bytes);
+        env::set_var("CHAIN_ID", hex::encode(chain_id_be_bytes));
+        env::set_var("DIFFICULTY", hex::encode(difficulty_be_bytes));
+
+        SuperCircuit::<
+            Fr,
+            TEST_MAX_TXS,
+            TEST_MAX_CALLDATA,
+            TEST_MAX_INNER_BLOCKS,
+            TEST_MOCK_RANDOMNESS,
+        >::build(block, circuits_params)
+        .unwrap()
+        .1
+    }
+
+    fn block_1tx() -> GethData {
+        let mut rng = ChaCha20Rng::seed_from_u64(2);
+
+        let chain_id = (*MOCK_CHAIN_ID).as_u64();
+
+        let bytecode = bytecode! {
+            GAS
+            STOP
+        };
+
+        let wallet_a = LocalWallet::new(&mut rng).with_chain_id(chain_id);
+
+        let addr_a = wallet_a.address();
+        let addr_b = address!("0x000000000000000000000000000000000000BBBB");
+
+        let mut wallets = HashMap::new();
+        wallets.insert(wallet_a.address(), wallet_a);
+
+        let mut block: GethData = TestContext::<2, 1>::new(
+            Some(vec![U256::zero()]),
+            |accs| {
+                accs[0].address(addr_b).balance(U256::from(1u64 << 20)).code(bytecode);
+                accs[1].address(addr_a).balance(U256::from(1u64 << 20));
+            },
+            |mut txs, accs| {
+                txs[0].from(accs[1].address).to(accs[0].address).gas(U256::from(1_000_000u64));
+            },
+            |block, _tx| block.number(0xcafeu64),
+        )
+        .unwrap()
+        .into();
+        block.sign(&wallets);
+        block
+    }
+
+    fn verify_circuit<C: CircuitExt<Fr>>(circuit: C) -> bool {
+        env::set_var("VERIFY_CONFIG", "./configs/verify_circuit.config");
 
         let mut rng = test_rng();
-        let params = gen_srs(10);
+        let params = gen_srs(TEST_CURRENT_K);
 
         let pk = gen_pk(&params, &circuit, None);
         let vk = pk.get_vk();

--- a/snark-verifier-sdk/src/evm_circuits/mpt_circuit.rs
+++ b/snark-verifier-sdk/src/evm_circuits/mpt_circuit.rs
@@ -11,6 +11,6 @@ impl<F: Field> CircuitExt<F> for MptCircuit<F> {
     }
 
     fn instances(&self) -> Vec<Vec<F>> {
-        vec![vec![]]
+        vec![]
     }
 }

--- a/snark-verifier-sdk/src/evm_circuits/mpt_circuit.rs
+++ b/snark-verifier-sdk/src/evm_circuits/mpt_circuit.rs
@@ -1,5 +1,4 @@
 use eth_types::Field;
-use halo2_base::halo2_proofs::plonk::Selector;
 use zkevm_circuits::mpt_circuit::MptCircuit;
 
 use crate::CircuitExt;
@@ -8,19 +7,10 @@ impl<F: Field> CircuitExt<F> for MptCircuit<F> {
     /// Return the number of instances of the circuit.
     /// This may depend on extra circuit parameters but NOT on private witnesses.
     fn num_instance(&self) -> Vec<usize> {
-        todo!()
+        vec![0]
     }
 
     fn instances(&self) -> Vec<Vec<F>> {
-        todo!()
-    }
-
-    fn accumulator_indices() -> Option<Vec<(usize, usize)>> {
-        todo!()
-    }
-
-    /// Output the simple selector columns (before selector compression) of the circuit
-    fn selectors(_: &Self::Config) -> Vec<Selector> {
-        todo!()
+        vec![vec![]]
     }
 }

--- a/snark-verifier-sdk/src/evm_circuits/poseidon_circuit.rs
+++ b/snark-verifier-sdk/src/evm_circuits/poseidon_circuit.rs
@@ -11,6 +11,6 @@ impl<F: Field> CircuitExt<F> for PoseidonCircuit<F> {
     }
 
     fn instances(&self) -> Vec<Vec<F>> {
-        vec![vec![]]
+        vec![]
     }
 }

--- a/snark-verifier-sdk/src/evm_circuits/poseidon_circuit.rs
+++ b/snark-verifier-sdk/src/evm_circuits/poseidon_circuit.rs
@@ -1,5 +1,4 @@
 use eth_types::Field;
-use halo2_base::halo2_proofs::plonk::Selector;
 use zkevm_circuits::poseidon_circuit::PoseidonCircuit;
 
 use crate::CircuitExt;
@@ -8,19 +7,10 @@ impl<F: Field> CircuitExt<F> for PoseidonCircuit<F> {
     /// Return the number of instances of the circuit.
     /// This may depend on extra circuit parameters but NOT on private witnesses.
     fn num_instance(&self) -> Vec<usize> {
-        todo!()
+        vec![0]
     }
 
     fn instances(&self) -> Vec<Vec<F>> {
-        todo!()
-    }
-
-    fn accumulator_indices() -> Option<Vec<(usize, usize)>> {
-        todo!()
-    }
-
-    /// Output the simple selector columns (before selector compression) of the circuit
-    fn selectors(_: &Self::Config) -> Vec<Selector> {
-        todo!()
+        vec![vec![]]
     }
 }

--- a/snark-verifier-sdk/src/evm_circuits/state_circuit.rs
+++ b/snark-verifier-sdk/src/evm_circuits/state_circuit.rs
@@ -1,5 +1,4 @@
 use eth_types::Field;
-use halo2_base::halo2_proofs::plonk::Selector;
 use zkevm_circuits::state_circuit::StateCircuit;
 
 use crate::CircuitExt;
@@ -8,19 +7,10 @@ impl<F: Field> CircuitExt<F> for StateCircuit<F> {
     /// Return the number of instances of the circuit.
     /// This may depend on extra circuit parameters but NOT on private witnesses.
     fn num_instance(&self) -> Vec<usize> {
-        todo!()
+        vec![0]
     }
 
     fn instances(&self) -> Vec<Vec<F>> {
-        todo!()
-    }
-
-    fn accumulator_indices() -> Option<Vec<(usize, usize)>> {
-        todo!()
-    }
-
-    /// Output the simple selector columns (before selector compression) of the circuit
-    fn selectors(_: &Self::Config) -> Vec<Selector> {
-        todo!()
+        vec![vec![]]
     }
 }

--- a/snark-verifier-sdk/src/evm_circuits/state_circuit.rs
+++ b/snark-verifier-sdk/src/evm_circuits/state_circuit.rs
@@ -11,6 +11,6 @@ impl<F: Field> CircuitExt<F> for StateCircuit<F> {
     }
 
     fn instances(&self) -> Vec<Vec<F>> {
-        vec![vec![]]
+        vec![]
     }
 }

--- a/snark-verifier-sdk/src/evm_circuits/super_circuit.rs
+++ b/snark-verifier-sdk/src/evm_circuits/super_circuit.rs
@@ -18,6 +18,6 @@ impl<
     }
 
     fn instances(&self) -> Vec<Vec<F>> {
-        vec![vec![]]
+        vec![]
     }
 }

--- a/snark-verifier-sdk/src/evm_circuits/super_circuit.rs
+++ b/snark-verifier-sdk/src/evm_circuits/super_circuit.rs
@@ -1,5 +1,4 @@
 use eth_types::Field;
-use halo2_base::halo2_proofs::plonk::Selector;
 use zkevm_circuits::super_circuit::SuperCircuit;
 
 use crate::CircuitExt;
@@ -15,19 +14,10 @@ impl<
     /// Return the number of instances of the circuit.
     /// This may depend on extra circuit parameters but NOT on private witnesses.
     fn num_instance(&self) -> Vec<usize> {
-        todo!()
+        vec![0]
     }
 
     fn instances(&self) -> Vec<Vec<F>> {
-        todo!()
-    }
-
-    fn accumulator_indices() -> Option<Vec<(usize, usize)>> {
-        todo!()
-    }
-
-    /// Output the simple selector columns (before selector compression) of the circuit
-    fn selectors(_: &Self::Config) -> Vec<Selector> {
-        todo!()
+        vec![vec![]]
     }
 }

--- a/snark-verifier-sdk/src/lib.rs
+++ b/snark-verifier-sdk/src/lib.rs
@@ -188,28 +188,3 @@ pub fn write_instances(instances: &[&[Fr]], path: impl AsRef<Path>) {
     let f = BufWriter::new(File::create(path).unwrap());
     bincode::serialize_into(f, &instances).unwrap();
 }
-
-#[cfg(feature = "zkevm")]
-mod zkevm {
-    use super::CircuitExt;
-    use eth_types::Field;
-    use zkevm_circuits::{evm_circuit::EvmCircuit, state_circuit::StateCircuit};
-
-    impl<F: Field> CircuitExt<F> for EvmCircuit<F> {
-        fn instances(&self) -> Vec<Vec<F>> {
-            vec![]
-        }
-        fn num_instance() -> Vec<usize> {
-            vec![]
-        }
-    }
-
-    impl<F: Field> CircuitExt<F> for StateCircuit<F> {
-        fn instances(&self) -> Vec<Vec<F>> {
-            vec![]
-        }
-        fn num_instance() -> Vec<usize> {
-            vec![]
-        }
-    }
-}


### PR DESCRIPTION
### Summary

1. For `EvmCircuit`, return zero for `num_instance` and an empty vector for `instances` (`accumulator_indices` and `selectors` are left as default).

2. Update other evm circuits as above.

3. Add test cases to test each circuit verification. Except `test_evm_circuit_verification` other cases are ignored.

### Test

The test case `test_evm_circuit_verification` could be passed as:
```
cargo test -F zkevm -- --nocapture test_evm_circuit_verification
```

### TODO

Will continue on fixing other evm circuits.