### PR TITLE
Restrict solc version (`<= 0.8.19`)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "anyhow"
+version = "1.0.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
+
+[[package]]
 name = "ark-std"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2597,6 +2603,7 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 name = "snark-verifier"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "ark-std",
  "bytes",
  "crossterm",
@@ -2606,6 +2613,7 @@ dependencies = [
  "hex",
  "itertools",
  "lazy_static",
+ "log",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -2615,6 +2623,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "rayon",
+ "regex",
  "revm",
  "rlp",
  "rustc-hash",

--- a/snark-verifier/Cargo.toml
+++ b/snark-verifier/Cargo.toml
@@ -4,13 +4,16 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+anyhow = "1.0"
 itertools = "0.10.3"
 lazy_static = "1.4.0"
+log = "0.4"
 num-bigint = "0.4.3"
 num-integer = "0.1.45"
 num-traits = "0.2.15"
 hex = "0.4"
 rand = "0.8"
+regex = "1.7.3"
 rustc-hash = "1.1.0"
 serde = { version = "1.0", features = ["derive"] }
 


### PR DESCRIPTION
### Summary

Restrict solc version for issue https://github.com/scroll-tech/scroll-zkevm/issues/147.

[solidity 0.8.20](https://github.com/ethereum/solidity/releases/tag/v0.8.20) sets the default target EVM version to Shanghai including `PUSH0`. But we use [rvm 2.3.1](https://github.com/scroll-tech/snark-verifier/blob/halo2-ecc-snark-verifier-0323/snark-verifier/Cargo.toml#LL29C21-L29C26) in snark-verifer, it considers [PUSH0 95_u8](https://github.com/bluealloy/revm/blob/v19/crates/revm/src/instructions.rs#L85) as `OpcodeNotFound`.

So fix to restrict solc version `<= 0.8.19` to exclude `PUSH0`.

### Test

Panic for solc `0.8.20`:
```
thread 'test_aggregation_api' panicked at 'solc version must be `<= 0.8.19`'
```
Test could pass for solc `0.8.19`.