### PR TITLE
fix-tob-scroll-16

### DIFF
--- a/snark-verifier/src/pcs/ipa/decider.rs
+++ b/snark-verifier/src/pcs/ipa/decider.rs
@@ -51,6 +51,7 @@ mod native {
             dk: &Self::DecidingKey,
             accumulators: Vec<IpaAccumulator<C, NativeLoader>>,
         ) -> bool {
+            assert!(!accumulators.is_empty());
             !accumulators
                 .into_iter()
                 .any(|accumulator| !Self::decide(dk, accumulator))

--- a/snark-verifier/src/pcs/kzg/decider.rs
+++ b/snark-verifier/src/pcs/kzg/decider.rs
@@ -55,15 +55,10 @@ mod native {
             dk: &Self::DecidingKey,
             accumulators: Vec<KzgAccumulator<M::G1Affine, NativeLoader>>,
         ) -> bool {
+            assert!(!accumulators.is_empty());
             !accumulators
                 .into_iter()
-                //.enumerate()
                 .any(|accumulator| {
-                    /*let decide = Self::decide(dk, accumulator);
-                    if !decide {
-                        panic!("{i}");
-                    }
-                    !decide*/
                     !Self::decide(dk, accumulator)
                 })
         }


### PR DESCRIPTION
TOB-SCROLL-16. Native PCS accumulation deciders accept an empty vector