### PR TITLE
Miss to make `verify_evm_calldata` public

### DIFF
--- a/snark-verifier-sdk/src/lib.rs
+++ b/snark-verifier-sdk/src/lib.rs
@@ -53,6 +53,8 @@ pub use evm_api::{
     gen_evm_verifier_gwc,
     // generate the bytecode that verifies proofs with keccak and KZG-BDFG
     gen_evm_verifier_shplonk,
+    // verify calldata with the bytecode (returns bool)
+    verify_evm_calldata,
     // verify instances and proofs with the bytecode (returns bool)
     verify_evm_proof,
 };


### PR DESCRIPTION
Sorry for missing to make `verify_evm_calldata` public in [previous PR](https://github.com/scroll-tech/snark-verifier/pull/19).