### PR TITLE
fix: set `halo2-lib` to `v0.1.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1291,7 +1291,7 @@ checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 [[package]]
 name = "halo2-base"
 version = "0.2.2"
-source = "git+https://github.com/scroll-tech/halo2-lib?branch=develop#c2ea19569db5fedd85a7465ee3841f23be8e7b22"
+source = "git+https://github.com/scroll-tech/halo2-lib?tag=v0.1.0#2c225864227e74b207d9f4b9e08c4d5f1afc69a1"
 dependencies = [
  "ff",
  "halo2_proofs 0.2.0 (git+https://github.com/axiom-crypto/halo2.git?tag=v2023_01_17)",
@@ -1307,7 +1307,7 @@ dependencies = [
 [[package]]
 name = "halo2-ecc"
 version = "0.2.2"
-source = "git+https://github.com/scroll-tech/halo2-lib?branch=develop#c2ea19569db5fedd85a7465ee3841f23be8e7b22"
+source = "git+https://github.com/scroll-tech/halo2-lib?tag=v0.1.0#2c225864227e74b207d9f4b9e08c4d5f1afc69a1"
 dependencies = [
  "ff",
  "group",

--- a/snark-verifier-sdk/Cargo.toml
+++ b/snark-verifier-sdk/Cargo.toml
@@ -17,7 +17,7 @@ serde_json = "1.0"
 bincode = "1.3.3"
 ark-std = { version = "0.4.0", features = ["print-trace"], optional = true }
 
-halo2-base = { git = "https://github.com/scroll-tech/halo2-lib.git", branch = "develop", default-features=false, features=["halo2-pse","display"] }
+halo2-base = { git = "https://github.com/scroll-tech/halo2-lib.git", tag = "v0.1.0", default-features=false, features=["halo2-pse","display"] }
 snark-verifier = { path = "../snark-verifier", default-features = false }
 
 # loader_evm

--- a/snark-verifier/Cargo.toml
+++ b/snark-verifier/Cargo.toml
@@ -15,7 +15,7 @@ rustc-hash = "1.1.0"
 serde = { version = "1.0", features = ["derive"] }
 
 # Use halo2-base as non-optional dependency because it re-exports halo2_proofs, halo2curves, and poseidon, using different repos based on feature flag "halo2-axiom" or "halo2-pse"
-halo2-base = { git = "https://github.com/scroll-tech/halo2-lib", branch = "develop", default-features=false, features=["halo2-pse","display"] }
+halo2-base = { git = "https://github.com/scroll-tech/halo2-lib", tag = "v0.1.0", default-features=false, features=["halo2-pse","display"] }
 # This poseidon is identical to PSE (for now) but uses axiom's halo2curves; otherwise would require patching
 poseidon-axiom = { git = "https://github.com/axiom-crypto/halo2.git", branch = "axiom/dev", package = "poseidon", optional = true }
 poseidon= { git = "https://github.com/privacy-scaling-explorations/poseidon", optional = true }
@@ -31,7 +31,7 @@ bytes = { version = "1.2", optional = true }
 rlp = { version = "0.5", default-features = false, features = ["std"], optional = true }
 
 # loader_halo2
-halo2-ecc = { git = "https://github.com/scroll-tech/halo2-lib", branch = "develop", optional = true, default-features=false, features=["halo2-pse","display"] }
+halo2-ecc = { git = "https://github.com/scroll-tech/halo2-lib", tag = "v0.1.0", optional = true, default-features=false, features=["halo2-pse","display"] }
 
 [dev-dependencies]
 ark-std = { version = "0.3.0", features = ["print-trace"] }


### PR DESCRIPTION
### Summary

The commit hash of `halo2-lib` is same with before.