### PR TITLE
Fix: cherry-pick pse pr#29 to let quotient has same number of chunk as it …

### DIFF
--- a/snark-verifier/src/system/halo2.rs
+++ b/snark-verifier/src/system/halo2.rs
@@ -178,6 +178,7 @@ struct Polynomials<'a, F: PrimeField> {
     cs: &'a ConstraintSystem<F>,
     zk: bool,
     query_instance: bool,
+    degree: usize,
     num_proof: usize,
     num_fixed: usize,
     num_permutation_fixed: usize,
@@ -234,6 +235,7 @@ impl<'a, F: PrimeField> Polynomials<'a, F> {
             cs,
             zk,
             query_instance,
+            degree,
             num_proof,
             num_fixed: cs.num_fixed_columns(),
             num_permutation_fixed: cs.permutation().get_columns().len(),
@@ -653,7 +655,7 @@ impl<'a, F: PrimeField> Polynomials<'a, F> {
             })
             .collect_vec();
         let numerator = Expression::DistributePowers(constraints, self.alpha().into());
-        QuotientPolynomial { chunk_degree: 1, numerator }
+        QuotientPolynomial { num_chunk: self.degree - 1, chunk_degree: 1, numerator }
     }
 
     fn accumulator_indices(

--- a/snark-verifier/src/util/protocol.rs
+++ b/snark-verifier/src/util/protocol.rs
@@ -146,13 +146,16 @@ where
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct QuotientPolynomial<F: Clone> {
+    // Note that `num_chunk` might be larger than necessary, due to the degree of
+    // constraint system (in the form of 2^k + 1)
+    pub num_chunk: usize,
     pub chunk_degree: usize,
     pub numerator: Expression<F>,
 }
 
 impl<F: Clone> QuotientPolynomial<F> {
     pub fn num_chunk(&self) -> usize {
-        Integer::div_ceil(&(self.numerator.degree() - 1), &self.chunk_degree)
+        self.num_chunk
     }
 }
 


### PR DESCRIPTION
This pr is a cherry-pick of [PR#29](https://github.com/privacy-scaling-explorations/snark-verifier/pull/29) from PSE's repo. 

This pr fixed the mismatch issue of quotient polynomial's degree. As we know the quotient polynomial's degree is always of form `2^k` in prover's side. The current code just use the max degree of custom gates / permutation / lookup. We should instead use `(self.numerator.degree() - 1).next_power_of_two()`.